### PR TITLE
Enable Ollama engine by default

### DIFF
--- a/ia-redacciones/README.md
+++ b/ia-redacciones/README.md
@@ -11,7 +11,7 @@ API REST **sin dependencias de pago** para tareas de:
 ## Requisitos
 - Windows 10/11
 - Python 3.13 (probado con `py --version`)
-- Sin GPU ni servicios externos obligatorios. **Opcional:** Ollama local.
+- Sin GPU ni servicios externos obligatorios. **Recomendado:** Ollama local para la generación.
 
 ## Instalación rápida en Windows (CMD)
 ```bat
@@ -23,7 +23,9 @@ py -3.13 -m venv .venv
 .venv\Scripts\activate
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-set ENGINE=rules
+REM Arranca Ollama en otro terminal: `ollama serve`
+set OLLAMA_BASE_URL=http://localhost:11434
+set ENGINE=ollama
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
@@ -37,7 +39,7 @@ runserver.bat
 ## .env (opcional)
 Crea `C:\ia-redacciones\.env` copiando desde `.env.example` y ajusta:
 ```
-ENGINE=rules
+ENGINE=ollama
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.1:8b
 ```
@@ -97,4 +99,5 @@ app/
 ## Notas
 - La corrección ortográfica usa un diccionario general: revisa nombres propios.
 - Las métricas y la división de oraciones son aproximadas.
-- Si activas Ollama y estableces `ENGINE=ollama`, el endpoint `/v1/draft` usará el modelo configurado para generar borradores más ricos.
+- Con la configuración por defecto (`ENGINE=ollama`), el endpoint `/v1/draft` usa el modelo definido en `OLLAMA_MODEL` (por defecto `llama3.1:8b`).
+- Si prefieres las plantillas internas sin IA, cambia `ENGINE=rules`.

--- a/ia-redacciones/app/core/config.py
+++ b/ia-redacciones/app/core/config.py
@@ -6,8 +6,8 @@ load_dotenv()
 
 @dataclass
 class Settings:
-    engine: str = os.getenv("ENGINE", "rules").lower()
-    ollama_base_url: str | None = os.getenv("OLLAMA_BASE_URL")
+    engine: str = os.getenv("ENGINE", "ollama").lower()
+    ollama_base_url: str | None = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     ollama_model: str = os.getenv("OLLAMA_MODEL", "llama3.1:8b")
 
 settings = Settings()

--- a/ia-redacciones/app/services/drafter.py
+++ b/ia-redacciones/app/services/drafter.py
@@ -23,14 +23,11 @@ def _rules_template(topic: str, tone: Tone, length: Length, language: str = "es"
     return "\n".join(lines)
 
 def draft(topic: str, tone: Tone = "neutral", length: Length = "medio", language: str = "es") -> str:
-    if settings.engine == "ollama" and settings.ollama_base_url:
-        try:
-            engine = OllamaEngine(settings.ollama_base_url, settings.ollama_model)
-            prompt = f"""Eres un redactor en {language}. Escribe un borrador sobre: '{topic}'.
-            Tono: {tone}. Longitud: {length}. Estructura con título, introducción, viñetas y cierre claro."""
-            return engine.generate(prompt)
-        except Exception:
-            # Fallback
-            return _rules_template(topic, tone, length, language)
-    else:
-        return _rules_template(topic, tone, length, language)
+    if settings.engine == "ollama":
+        if not settings.ollama_base_url:
+            raise RuntimeError("OLLAMA_BASE_URL no está configurada")
+        engine = OllamaEngine(settings.ollama_base_url, settings.ollama_model)
+        prompt = f"""Eres un redactor en {language}. Escribe un borrador sobre: '{topic}'.
+        Tono: {tone}. Longitud: {length}. Estructura con título, introducción, viñetas y cierre claro."""
+        return engine.generate(prompt)
+    return _rules_template(topic, tone, length, language)


### PR DESCRIPTION
## Summary
- switch the default configuration to use the Ollama engine and localhost endpoint
- ensure the drafter service always delegates to Ollama when configured and fail fast if misconfigured
- document the new defaults and setup steps in the README

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d594f0a3f0832fbbe1d6b01a2e6754